### PR TITLE
Version 0.8.2

### DIFF
--- a/TheIdleScrolls_Core/Components/TitleBearerComponent.cs
+++ b/TheIdleScrolls_Core/Components/TitleBearerComponent.cs
@@ -39,4 +39,10 @@ namespace TheIdleScrolls_Core.Components
                 ?? "";
         }
     }
+
+    public record TitleEarnedMessage(Entity Character, string Title) : IMessage
+    {
+        string IMessage.BuildMessage() => $"{Character.GetName()} earned the title of '{Title}'";
+        IMessage.PriorityLevel IMessage.GetPriority() => IMessage.PriorityLevel.VeryHigh;
+    }
 }

--- a/TheIdleScrolls_Core/Definitions.cs
+++ b/TheIdleScrolls_Core/Definitions.cs
@@ -51,10 +51,10 @@ namespace TheIdleScrolls_Core
 
             public const int    LevelsPerPerkPoint          = 5;
             public const int    PerkPointLevelLimit         = 200;
-            public const double BasicDamageIncrease         = 0.10;
+            public const double BasicDamageIncrease         = 0.12;
             public const double BasicAttackSpeedIncrease    = 0.05;
             public const double BasicDefenseIncrease        = 0.08;
-            public const double BasicTimeIncrease           = 0.05;
+            public const double BasicTimeIncrease           = 0.12;
             public const double BigPerkFactor               = 1.5;
             public const double MasterPerkMultiplier        = 0.1;
             public const double SavantXpMultiplier          = 0.3;

--- a/TheIdleScrolls_Core/Definitions.cs
+++ b/TheIdleScrolls_Core/Definitions.cs
@@ -128,7 +128,7 @@ namespace TheIdleScrolls_Core
             public const string CraftingSlots = "CraftingSlot";
             public const string ActiveCrafts = "ActiveCraftingSlot";
             public const string CraftingSpeed = "CraftingSpeed";
-            public const string CraftingCost = "CraftingCost";
+            public const string CraftingCostEfficiency = "CraftingCostEfficiency";
         }
 
         public static class DropRestrictions
@@ -276,10 +276,10 @@ namespace TheIdleScrolls_Core
         public static int CalculateCraftingCost(Entity item, Entity? crafter)
         {
             int baseCost = item.GetComponent<ItemRefinableComponent>()?.Cost ?? 100;
-            double cost = crafter?.ApplyAllApplicableModifiers(baseCost, 
-                [Tags.CraftingCost],
-                crafter.GetTags()) ?? baseCost;
-            return (int)Math.Ceiling(Math.Max(cost, 1.0));
+            double efficiency = crafter?.ApplyAllApplicableModifiers(1.0, 
+                [Tags.CraftingCostEfficiency],
+                crafter.GetTags()) ?? 1.0;
+            return (int)Math.Ceiling(Math.Max(baseCost / ((efficiency == 0) ? 0.1 : efficiency), 1.0));
         }
     }
 }

--- a/TheIdleScrolls_Core/Definitions.cs
+++ b/TheIdleScrolls_Core/Definitions.cs
@@ -58,8 +58,8 @@ namespace TheIdleScrolls_Core
             public const double BigPerkFactor               = 1.5;
             public const double MasterPerkMultiplier        = 0.1;
             public const double SavantXpMultiplier          = 0.3;
-            public const double TradeoffPerkBonus           = 1.09;    
-            public const double TradeoffPerkMalus           = 0.94;    
+            public const double TradeoffPerkBonus           = 1.05;    
+            public const double TradeoffPerkMalus           = 0.97;    
         }
 
         public static class DungeonIds

--- a/TheIdleScrolls_Core/Definitions.cs
+++ b/TheIdleScrolls_Core/Definitions.cs
@@ -58,6 +58,8 @@ namespace TheIdleScrolls_Core
             public const double BigPerkFactor               = 1.5;
             public const double MasterPerkMultiplier        = 0.1;
             public const double SavantXpMultiplier          = 0.3;
+            public const double TradeoffPerkBonus           = 1.09;    
+            public const double TradeoffPerkMalus           = 0.94;    
         }
 
         public static class DungeonIds

--- a/TheIdleScrolls_Core/Definitions.cs
+++ b/TheIdleScrolls_Core/Definitions.cs
@@ -255,11 +255,14 @@ namespace TheIdleScrolls_Core
 
         public static double CalculateRefiningDuration(Entity item, Entity? crafter)
         {
-            double matMulti = Math.Pow(item.GetBlueprint()!.GetMaterial().PowerMultiplier, 0.2);
-            double tierMulti = Math.Pow(item.GetBlueprint()!.GetDropLevel() / 10, 0.2);
-            double typeMulti = item.IsWeapon() ? Stats.CraftingCostWeaponMultiplier : 1.0;
-
-            double baseDuration = Stats.CraftingBaseDuration * matMulti * tierMulti * typeMulti;
+            double baseDuration = Stats.CraftingBaseDuration;
+            if (item.GetBlueprint()?.GetMaterial()?.Id != MaterialId.Simple)
+            {
+                double matMulti = Math.Pow(item.GetBlueprint()!.GetMaterial().PowerMultiplier, 0.2);
+                double tierMulti = Math.Pow(item.GetBlueprint()!.GetDropLevel() / 10, 0.2);
+                double typeMulti = item.IsWeapon() ? Stats.CraftingCostWeaponMultiplier : 1.0;
+                baseDuration *= matMulti * tierMulti * typeMulti;
+            }
             double speed = crafter?.ApplyAllApplicableModifiers(1.0, 
                 [Tags.CraftingSpeed], 
                 crafter.GetTags()) ?? 1.0;

--- a/TheIdleScrolls_Core/Definitions.cs
+++ b/TheIdleScrolls_Core/Definitions.cs
@@ -17,7 +17,7 @@ namespace TheIdleScrolls_Core
             public const double TimeShieldBonusPerLevel = 0.02;
             public const double AttackDamagePerAbilityLevel = 0.02;
             public const double AttackSpeedPerAbilityLevel = 0.005;
-            public const double DualWieldAttackSpeedMulti = 0.2;
+            public const double DualWieldAttackSpeedMulti = 0.1;
             public const double DefensePerAbilityLevel = 0.02;
             public const double MaxAttacksPerSecond = 10.0;
 

--- a/TheIdleScrolls_Core/Definitions.cs
+++ b/TheIdleScrolls_Core/Definitions.cs
@@ -107,6 +107,8 @@ namespace TheIdleScrolls_Core
             public const string Weapon = "Weapon";
             public const string Armor = "Armor";
             public const string Shield = "Shield";
+            public const string MainHand = "MainHand";
+            public const string OffHand = "OffHand";
             
             public const string Melee = "Melee";
             public const string Ranged = "Ranged";

--- a/TheIdleScrolls_Core/Items/IItemEntity.cs
+++ b/TheIdleScrolls_Core/Items/IItemEntity.cs
@@ -1,16 +1,28 @@
-﻿using TheIdleScrolls_Core.Definitions;
+﻿using MiniECS;
+using TheIdleScrolls_Core.Definitions;
 
 namespace TheIdleScrolls_Core.Items
 {
+    using CandidateComparator = Func<Entity, Entity, ComparisonResult>;
+
     public interface IItemEntity
     {
         public uint Id { get; }
         public string Name { get; }
+        public string Type { get; }
+        public string RelatedAbility { get; }
         public string Description { get; }
         public List<EquipmentSlot> Slots { get; }
+        public double Encumbrance { get; }
+        public int DropLevel { get; }
         public int Quality { get; }
         public int Value { get; }
         public (int Cost, double Duration) Refining { get; }
         public bool Crafted { get; }
+        public WeaponGenus? WeaponAspect { get; }
+        public ArmorGenus? ArmorAspect { get; }
+        public bool IsEquipped { get; }
+
+        public List<ComparisonResult> CompareToEquipment(CandidateComparator comparator);
     }
 }

--- a/TheIdleScrolls_Core/Items/ItemComparator.cs
+++ b/TheIdleScrolls_Core/Items/ItemComparator.cs
@@ -1,0 +1,82 @@
+﻿using MiniECS;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TheIdleScrolls_Core.Components;
+
+namespace TheIdleScrolls_Core.Items
+{
+    using ValueExtractor = Func<Entity, double>;
+    using CandidateComparator = Func<Entity, List<Entity>, List<RelativeValue>>;
+
+    public enum RelativeQuality
+    {
+        Better,
+        Equal,
+        Worse
+    }
+
+    public enum RelativeValue
+    {
+        Higher,
+        Equal,
+        Lower
+    }
+
+    public static class Extensions
+    {
+        public static RelativeQuality ToRelativeQuality(this RelativeValue value, bool higherIsBetter = true)
+        {
+            if (value == RelativeValue.Equal)
+            {
+                return RelativeQuality.Equal;
+            }
+            else
+            {
+                return (higherIsBetter && value == RelativeValue.Higher) || (!higherIsBetter && value == RelativeValue.Lower) 
+                        ? RelativeQuality.Better 
+                        : RelativeQuality.Worse;
+            }
+        }
+    }
+
+        public static class ItemComparator
+    {
+        private static ValueExtractor GetDamage => item => item.GetComponent<WeaponComponent>()?.Damage ?? 0.0;
+        private static ValueExtractor GetCooldown => item => item.GetComponent<WeaponComponent>()?.Cooldown ?? 0.0;
+        private static ValueExtractor GetDps => item => (item.GetComponent<WeaponComponent>()?.Damage ?? 0.0) /
+                                                        (item.GetComponent<WeaponComponent>()?.Cooldown ?? 1.0);
+        private static ValueExtractor GetArmor => item => item.GetComponent<ArmorComponent>()?.Armor ?? 0.0;
+        private static ValueExtractor GetEvasion => item => item.GetComponent<ArmorComponent>()?.Evasion ?? 0.0;
+        private static ValueExtractor GetEncumbrance => item => item.GetComponent<EquippableComponent>()?.Encumbrance ?? 0.0;
+
+        public static CandidateComparator CompareDamage      => (a, b) => Compare(a, b, GetDamage);
+        public static CandidateComparator CompareCooldown    => (a, b) => Compare(a, b, GetCooldown);
+        public static CandidateComparator CompareDps         => (a, b) => Compare(a, b, GetDps);
+        public static CandidateComparator CompareArmor       => (a, b) => Compare(a, b, GetArmor);
+        public static CandidateComparator CompareEvasion     => (a, b) => Compare(a, b, GetEvasion);
+        public static CandidateComparator CompareEncumbrance => (a, b) => Compare(a, b, GetEncumbrance);
+
+        private static RelativeValue Compare(Entity firstItem, Entity secondItem, ValueExtractor valueExtractor)
+        {
+            return CompareValues(valueExtractor(firstItem), valueExtractor(secondItem));
+        }
+
+        private static List<RelativeValue> Compare(Entity item, List<Entity> candidates, 
+                                                            ValueExtractor valueExtractor)
+        {
+            return candidates.Select(candidate => Compare(item, candidate, valueExtractor)).ToList();
+        }
+
+        private static RelativeValue CompareValues(double first, double second)
+        {
+            if (first == second)
+            {
+                return RelativeValue.Equal;
+            }
+            return first > second ? RelativeValue.Higher : RelativeValue.Lower;
+        }
+    }
+}

--- a/TheIdleScrolls_Core/Items/ItemEntityWrapper.cs
+++ b/TheIdleScrolls_Core/Items/ItemEntityWrapper.cs
@@ -14,20 +14,17 @@ namespace TheIdleScrolls_Core.Items
     {
         public uint Id => Item.Id;
         public string Name => Item.GetName();
-
         public string Description => GenerateDescription();
-
         public List<EquipmentSlot> Slots => Item.GetRequiredSlots();
-
         public int Quality => Item.GetComponent<ItemQualityComponent>()?.Quality ?? 0;
-
         public int Value => Item.GetComponent<ItemValueComponent>()?.Value ?? 0;
-
         public (int Cost, double Duration) Refining => (Functions.CalculateCraftingCost(Item, Owner), 
                                                         Functions.CalculateRefiningDuration(Item, Owner));
-
         public bool Crafted => Item.GetComponent<ItemRefinableComponent>()?.Refined ?? false;
 
+        public bool IsEquipped => Owner?.GetComponent<EquipmentComponent>()?.GetItems()?.Contains(Item) ?? false;
+        
+        
         private Entity Item { get; }
         private Entity? Owner { get; }
 
@@ -41,8 +38,52 @@ namespace TheIdleScrolls_Core.Items
             Owner = owner;
         }
 
+        private List<Entity> FindItemsToCompareTo()
+        {
+            if (IsEquipped)
+            {
+                return [];
+            }
+
+            bool IsComparable(Entity item)
+            {
+                if (item == Item)
+                {
+                    return false;
+                }
+                if (item.IsWeapon() != Item.IsWeapon()
+                    || item.IsArmor() != Item.IsArmor()
+                    || item.IsShield() != Item.IsShield())
+                {
+                    return false;
+                }
+                var itemSlots = item.GetRequiredSlots();
+                return itemSlots.All(Slots.Contains) || Slots.All(itemSlots.Contains);
+            }
+
+            var items = Owner?.GetComponent<EquipmentComponent>()?.GetItems() ?? [];
+            return items.Where(IsComparable)
+                        .ToList();
+        }
+
         private string GenerateDescription()
         {
+            var comparableItems = FindItemsToCompareTo();
+            string compToString(List<RelativeValue> results, bool higherIsBetter)
+            {
+                var relativeQualities = results.Select(r => r.ToRelativeQuality(higherIsBetter));
+                if (results.Count == 0)
+                {
+                    return "";
+                }
+                return " [" + String.Join("", relativeQualities.Select(cr => cr switch 
+                    { 
+                        RelativeQuality.Better => '+', 
+                        RelativeQuality.Worse => '-',
+                        _ => '='
+                    })) + "]";
+            }
+
             var itemComp = Item.GetComponent<ItemComponent>()!;
             string description = $"Type: {itemComp.Blueprint.GetFamilyDescription().Name}";
 
@@ -75,20 +116,21 @@ namespace TheIdleScrolls_Core.Items
             var weaponComp = Item.GetComponent<WeaponComponent>();
             if (weaponComp != null)
             {
-                description += $"; Damage: {weaponComp.Damage} [{(weaponComp.Damage / weaponComp.Cooldown):#.##} DPS]; ";
-                description += $"Attack Time: {weaponComp.Cooldown} s";
+                description += $"; Damage: {weaponComp.Damage}{compToString(ItemComparator.CompareDamage(Item, comparableItems), true)}";
+                description += $"; Attack Time: {weaponComp.Cooldown} s{compToString(ItemComparator.CompareCooldown(Item, comparableItems), false)}";
+                description += $"; DPS: {(weaponComp.Damage / weaponComp.Cooldown):#.##}{compToString(ItemComparator.CompareDps(Item, comparableItems), true)}";
             }
 
             var armorComp = Item.GetComponent<ArmorComponent>();
             if (armorComp != null)
             {
-                description += armorComp.Armor != 0.0 ? $"; Armor: {armorComp.Armor}" : "";
+                description += armorComp.Armor != 0.0 ? $"; Armor: {armorComp.Armor}{compToString(ItemComparator.CompareArmor(Item, comparableItems), true)}" : "";
                 description += armorComp.Evasion != 0.0 ? $"; Evasion: {armorComp.Evasion}" : "";
             }
 
             if (equipComp != null)
             {
-                description += equipComp.Encumbrance != 0.0 ? $"; Encumbrance: {equipComp.Encumbrance}%" : "";
+                description += equipComp.Encumbrance != 0.0 ? $"; Encumbrance: {equipComp.Encumbrance}%{compToString(ItemComparator.CompareEncumbrance(Item, comparableItems), false)}" : "";
             }
 
             var valueComp = Item.GetComponent<ItemValueComponent>();
@@ -99,25 +141,5 @@ namespace TheIdleScrolls_Core.Items
             return description;
         }
 
-        private string GetItemTypeName()
-        {
-            if (Item.IsWeapon())
-                return LocalizedStrings.Equip_Weapon;
-            if (Item.IsShield())
-                return LocalizedStrings.Equip_Shield;
-            if (Slots.Count == 0 || !Item.IsArmor()) // Should not happen with the current item kingdom
-                return "??";
-
-            if (Slots.Count > 1)
-                return "Custom Gear"; // Does not currently exist
-            return Slots[0] switch
-            {
-                EquipmentSlot.Head => LocalizedStrings.Equip_HeadArmor,
-                EquipmentSlot.Chest => LocalizedStrings.Equip_ChestArmor,
-                EquipmentSlot.Arms => LocalizedStrings.Equip_ArmArmor,
-                EquipmentSlot.Legs => LocalizedStrings.Equip_LegArmor,
-                _ => "??",
-            };
-        }
     }
 }

--- a/TheIdleScrolls_Core/Items/ItemKingdom.cs
+++ b/TheIdleScrolls_Core/Items/ItemKingdom.cs
@@ -11,7 +11,10 @@ namespace TheIdleScrolls_Core.Items
 {
     public record EquippableDescription(List<EquipmentSlot> Slots, double Encumbrance);
 
-    public record WeaponGenus(double BaseDamage, double BaseCooldown);
+    public record WeaponGenus(double BaseDamage, double BaseCooldown)
+    {
+        public double Dps => (BaseCooldown != 0.0) ? BaseDamage / BaseCooldown : 0.0;
+    }
 
     public record ArmorGenus(double BaseArmor, double BaseEvasion);
 

--- a/TheIdleScrolls_Core/Modifiers/Modifier.cs
+++ b/TheIdleScrolls_Core/Modifiers/Modifier.cs
@@ -88,7 +88,7 @@ namespace TheIdleScrolls_Core.Modifiers
                 Tags.CraftingSlots,
                 Tags.ActiveCrafts,
                 Tags.CraftingSpeed,
-                Tags.CraftingCost,
+                Tags.CraftingCostEfficiency,
                 Tags.TimeShield
             ];
             targetTags = targetTags.Where(t => allTags.Contains(t)).ToList();

--- a/TheIdleScrolls_Core/Properties/LocalizedStrings.Designer.cs
+++ b/TheIdleScrolls_Core/Properties/LocalizedStrings.Designer.cs
@@ -772,6 +772,15 @@ namespace TheIdleScrolls_Core.Properties {
         }
         
         /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Main Hand ähnelt.
+        /// </summary>
+        internal static string MainHand {
+            get {
+                return ResourceManager.GetString("MainHand", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Sucht eine lokalisierte Zeichenfolge, die Goblin Knight ähnelt.
         /// </summary>
         internal static string MOB_1_CAV {
@@ -1416,6 +1425,15 @@ namespace TheIdleScrolls_Core.Properties {
         internal static string MOB_ZOMBIE {
             get {
                 return ResourceManager.GetString("MOB_ZOMBIE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Offhand ähnelt.
+        /// </summary>
+        internal static string OffHand {
+            get {
+                return ResourceManager.GetString("OffHand", resourceCulture);
             }
         }
         

--- a/TheIdleScrolls_Core/Properties/LocalizedStrings.Designer.cs
+++ b/TheIdleScrolls_Core/Properties/LocalizedStrings.Designer.cs
@@ -583,11 +583,11 @@ namespace TheIdleScrolls_Core.Properties {
         }
         
         /// <summary>
-        ///   Sucht eine lokalisierte Zeichenfolge, die Crafting Cost ähnelt.
+        ///   Sucht eine lokalisierte Zeichenfolge, die Crafting cost efficiency ähnelt.
         /// </summary>
-        internal static string CraftingCost {
+        internal static string CraftingCostEfficiency {
             get {
-                return ResourceManager.GetString("CraftingCost", resourceCulture);
+                return ResourceManager.GetString("CraftingCostEfficiency", resourceCulture);
             }
         }
         

--- a/TheIdleScrolls_Core/Properties/LocalizedStrings.Designer.cs
+++ b/TheIdleScrolls_Core/Properties/LocalizedStrings.Designer.cs
@@ -1330,7 +1330,7 @@ namespace TheIdleScrolls_Core.Properties {
         }
         
         /// <summary>
-        ///   Sucht eine lokalisierte Zeichenfolge, die The Three Executors ähnelt.
+        ///   Sucht eine lokalisierte Zeichenfolge, die Executioner Trio ähnelt.
         /// </summary>
         internal static string MOB_TRIO {
             get {

--- a/TheIdleScrolls_Core/Properties/LocalizedStrings.resx
+++ b/TheIdleScrolls_Core/Properties/LocalizedStrings.resx
@@ -541,7 +541,7 @@
     <value>Slithering Construct</value>
   </data>
   <data name="MOB_TRIO" xml:space="preserve">
-    <value>The Three Executors</value>
+    <value>Executioner Trio</value>
   </data>
   <data name="MOB_VENGEFULDUMMY" xml:space="preserve">
     <value>Vengeful Dummy</value>

--- a/TheIdleScrolls_Core/Properties/LocalizedStrings.resx
+++ b/TheIdleScrolls_Core/Properties/LocalizedStrings.resx
@@ -354,6 +354,9 @@
   <data name="Local" xml:space="preserve">
     <value>local</value>
   </data>
+  <data name="MainHand" xml:space="preserve">
+    <value>Main Hand</value>
+  </data>
   <data name="MOB_1-CAV" xml:space="preserve">
     <value>Goblin Knight</value>
   </data>
@@ -569,6 +572,9 @@
   </data>
   <data name="MOB_ZOMBIE" xml:space="preserve">
     <value>Zombie</value>
+  </data>
+  <data name="OffHand" xml:space="preserve">
+    <value>Offhand</value>
   </data>
   <data name="OGRE" xml:space="preserve">
     <value>Ogre</value>

--- a/TheIdleScrolls_Core/Properties/LocalizedStrings.resx
+++ b/TheIdleScrolls_Core/Properties/LocalizedStrings.resx
@@ -291,8 +291,8 @@
   <data name="CLASS_X_X" xml:space="preserve">
     <value>Monk</value>
   </data>
-  <data name="CraftingCost" xml:space="preserve">
-    <value>Crafting Cost</value>
+  <data name="CraftingCostEfficiency" xml:space="preserve">
+    <value>Crafting cost efficiency</value>
   </data>
   <data name="CraftingSlot" xml:space="preserve">
     <value>Crafting Slot(s)</value>

--- a/TheIdleScrolls_Core/Quests/EndgameQuest.cs
+++ b/TheIdleScrolls_Core/Quests/EndgameQuest.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using TheIdleScrolls_Core.Components;
 using TheIdleScrolls_Core.Definitions;
 using TheIdleScrolls_Core.GameWorld;
+using TheIdleScrolls_Core.Resources;
 using TheIdleScrolls_Core.Systems;
 
 namespace TheIdleScrolls_Core.Quests
@@ -84,7 +85,9 @@ namespace TheIdleScrolls_Core.Quests
                     if (titleComp != null)
                     {
                         int deaths = entity.GetComponent<PlayerProgressComponent>()?.Data.Losses ?? 1;
-                        titleComp.AddTitle(deaths == 0 ? Titles.ConquerorHC : Titles.Conqueror);
+                        string titleId = deaths == 0 ? Titles.ConquerorHC : Titles.Conqueror;
+                        titleComp.AddTitle(titleId);
+                        postMessageCallback(new TitleEarnedMessage(entity, TitleList.GetTitle(titleId)?.Text ?? titleId));
                     }
                 }
             }

--- a/TheIdleScrolls_Core/Resources/AchievementList.cs
+++ b/TheIdleScrolls_Core/Resources/AchievementList.cs
@@ -261,6 +261,7 @@ namespace TheIdleScrolls_Core.Resources
                 }
             }
             int mobsForStyles = 200;
+            int mobsForAdvStyles = 1000;
             achievements.Add(new(Abilities.DualWield, "Dual Wielder", 
                 $"Defeat {mobsForStyles} enemies while using two weapons",
                 tautology,
@@ -268,12 +269,66 @@ namespace TheIdleScrolls_Core.Resources
                 { 
                     Reward = new AbilityReward(Abilities.DualWield)
                 });
+            achievements.Add(new("Adv" + Abilities.DualWield, "Advanced Dual Wielder",
+                $"Defeat {mobsForAdvStyles} enemies while using two weapons",
+                Conditions.AchievementUnlockedCondition(Abilities.DualWield),
+                Conditions.MobsDefeatedConditionallyCondition(Tags.DualWield, mobsForAdvStyles))
+            {
+                Reward = new PerkReward(new("Adv" + Abilities.DualWield, "Weapon Block", 
+                    $"Gain {3}/{6}/{10} global base evasion rating per level of the Two Weapons ability", 
+                    [UpdateTrigger.AbilityIncreased], 
+                    (l, e, w, c) => {
+                        int level = e.GetComponent<AbilitiesComponent>()?
+                                        .GetAbility(Abilities.DualWield)?.Level ?? 0;
+                        int bonus = l switch
+                        {
+                            1 => 3,
+                            2 => 6,
+                            3 => 10,
+                            _ => 0
+                        };
+                        return [
+                            new("AdvDW_ev", ModifierType.AddBase, level * bonus, [Tags.EvasionRating, Tags.Global], [Tags.DualWield])
+                        ];
+                    })
+                {
+                    MaxLevel = 3
+                })
+            });
             achievements.Add(new(Abilities.Shielded, "Shieldbearer",
-                $"Defeat {mobsForStyles} enemies while carrying a shield",
+                $"Defeat {mobsForStyles} enemies while using a shield",
                 tautology,
                 Conditions.MobsDefeatedConditionallyCondition(Tags.Shielded, mobsForStyles))
             {
                 Reward = new AbilityReward(Abilities.Shielded)
+            });
+            achievements.Add(new("Adv" + Abilities.Shielded, "Advanced Shieldbearer",
+                $"Defeat {mobsForAdvStyles} enemies while using a shield",
+                Conditions.AchievementUnlockedCondition(Abilities.Shielded),
+                Conditions.MobsDefeatedConditionallyCondition(Tags.Shielded, mobsForAdvStyles))
+            {
+                Reward = new PerkReward(new("Adv" + Abilities.Shielded, "Shield Bash", 
+                    $"Every third attack, gain {4}/{7}/{10} base damage + {1}/{2}/{4} per level of quality on your shield", 
+                    [UpdateTrigger.EquipmentChanged, UpdateTrigger.AttackPerformed],
+                    (l, e, w, c) => {
+                        int quality = e.GetComponent<EquipmentComponent>()
+                                        ?.GetItems()?.FirstOrDefault(i => i.IsShield())
+                                        ?.GetComponent<ItemQualityComponent>()?.Quality ?? 0;
+                        int bonus = l switch
+                        {
+                            1 => 2 * quality + 4,
+                            2 => 3 * quality + 7,
+                            3 => 4 * quality + 10,
+                            _ => 0
+                        };
+                        bool active = (e.GetComponent<BattlerComponent>()?.AttacksPerformed ?? 0) % 3 == 0;
+                        return [
+                            new("AdvSh_dmg", ModifierType.AddBase, active ? bonus : 0, [Tags.Damage], [Tags.Shielded])
+                        ];
+                    })
+                { 
+                    MaxLevel = 3 
+                })
             });
             achievements.Add(new(Abilities.SingleHanded, "Fencer",
                 $"Defeat {mobsForStyles} enemies while wielding only one one-handed weapon",
@@ -282,12 +337,56 @@ namespace TheIdleScrolls_Core.Resources
             {
                 Reward = new AbilityReward(Abilities.SingleHanded)
             });
+            achievements.Add(new("Adv" + Abilities.SingleHanded, "Advanced Fencer",
+                $"Defeat {mobsForAdvStyles} enemies while wielding only one one-handed weapon",
+                Conditions.AchievementUnlockedCondition(Abilities.SingleHanded),
+                Conditions.MobsDefeatedConditionallyCondition(Tags.SingleHanded, mobsForAdvStyles))
+            {
+                Reward = new PerkReward(new("Adv" + Abilities.SingleHanded, "Seize the Moment",
+                    $"While fighting single-handedly, gain {0.07:0.#%}/{0.15:0.#%}/{0.25:0.#%} increased attack speed while evading", 
+                    [],
+                    (l, e, w, c) => [
+                        new("AdvSH_as", ModifierType.Increase,
+                        l switch { 1 => 0.07, 2 => 0.15, 3 => 0.25, _ => 0.0 },
+                        [Tags.AttackSpeed], [Tags.SingleHanded, Tags.Evading])    
+                    ])
+                {
+                    MaxLevel = 3
+                })
+            });
             achievements.Add(new(Abilities.TwoHanded, "Wide Swings",
                 $"Defeat {mobsForStyles} enemies while wielding a two-handed weapon",
                 tautology,
                 Conditions.MobsDefeatedConditionallyCondition(Tags.TwoHanded, mobsForStyles))
             {
                 Reward = new AbilityReward(Abilities.TwoHanded)
+            });
+            achievements.Add(new("Adv" + Abilities.TwoHanded, "Advanced Wide Swings",
+                $"Defeat {mobsForAdvStyles} enemies while wielding a two-handed weapon",
+                Conditions.AchievementUnlockedCondition(Abilities.TwoHanded),
+                Conditions.MobsDefeatedConditionallyCondition(Tags.TwoHanded, mobsForAdvStyles))
+            {
+                Reward = new PerkReward(new("Adv" + Abilities.TwoHanded, "Distance Control",
+                    $"Gain {0.3:0.#%}/{0.6:0.#%}/{1.0:0.#%} of your two-handed weapon's damage as global base armor rating", 
+                    [UpdateTrigger.EquipmentChanged],
+                    (l, e, w, c) => { 
+                        double dmg = e.GetComponent<EquipmentComponent>()
+                                    ?.GetItemInSlot(EquipmentSlot.Hand)
+                                    ?.GetComponent<WeaponComponent>()?.Damage ?? 0;
+                        double bonus = l switch
+                        {
+                            1 => 0.3,
+                            2 => 0.6,
+                            3 => 1.0,
+                            _ => 0.0
+                        };
+                        return [
+                            new("AdvTH_ar", ModifierType.AddBase, bonus * dmg, [Tags.ArmorRating, Tags.Global], [Tags.TwoHanded])
+                        ];
+                    })
+                {
+                    MaxLevel = 3
+                })
             });
 
             // Fighting style level achievements

--- a/TheIdleScrolls_Core/Resources/AchievementList.cs
+++ b/TheIdleScrolls_Core/Resources/AchievementList.cs
@@ -929,8 +929,8 @@ namespace TheIdleScrolls_Core.Resources
                                 => PerkFactory.MakeStaticPerk($"{id}{level}", "Crafting Journeyman",
                                     $"Gain a discount for all crafts",
                                     ModifierType.Increase,
-                                    -0.2,
-                                    [Tags.CraftingCost],
+                                    0.25,
+                                    [Tags.CraftingCostEfficiency],
                                     [], true),
                 ("ABL_CRAFT", 75)
                                 => PerkFactory.MakeStaticPerk($"{id}{level}", "Crafting Expert",

--- a/TheIdleScrolls_Core/Resources/AchievementList.cs
+++ b/TheIdleScrolls_Core/Resources/AchievementList.cs
@@ -456,7 +456,7 @@ namespace TheIdleScrolls_Core.Resources
                 (  5000, "Fence"),
                 ( 25000, "Merchant"),
                 (100000, "Wholesaler"),
-                (500000, "Patritian"),
+                (250000, "Patritian"),
             ];
             for (int i = 0; i < ranks.Length; i++)
             {

--- a/TheIdleScrolls_Core/Resources/AchievementList.cs
+++ b/TheIdleScrolls_Core/Resources/AchievementList.cs
@@ -751,7 +751,7 @@ namespace TheIdleScrolls_Core.Resources
                                 [Tags.Defense],
                                 [Tags.FirstStrike, Abilities.Polearm]),
                 ("SBL", 25) => new($"{id}{level}", "Sneak Attack",
-                                $"Deal 100% more damage per 25 level of the {Properties.LocalizedStrings.SBL} ability with short blades on " +
+                                $"Deal 100% more damage per 25 levels of the {Properties.LocalizedStrings.SBL} ability with short blades on " +
                                 $"your first attack every battle",
                                 [UpdateTrigger.AbilityIncreased],
                                 (_, e, w, c) =>

--- a/TheIdleScrolls_Core/Resources/AchievementList.cs
+++ b/TheIdleScrolls_Core/Resources/AchievementList.cs
@@ -555,7 +555,7 @@ namespace TheIdleScrolls_Core.Resources
                 (  5000, "Fence"),
                 ( 25000, "Merchant"),
                 (100000, "Wholesaler"),
-                (250000, "Patritian"),
+                (250000, "Patrician"),
             ];
             for (int i = 0; i < ranks.Length; i++)
             {

--- a/TheIdleScrolls_Core/Resources/AchievementList.cs
+++ b/TheIdleScrolls_Core/Resources/AchievementList.cs
@@ -699,6 +699,11 @@ namespace TheIdleScrolls_Core.Resources
 
         public static IAchievementReward? GetPerkForLeveledAchievement(string id, int level)
         {
+            const double DualWieldKeystone = 0.2;
+            const double ShieldedKeystone = 0.001;
+            const double SingleHandedKeystone = 0.02;
+            const double TwoHandedKeystone = 0.01;
+
             var perk = (id, level) switch
             {
                 ("LVL", 150) => PerkFactory.MakeStaticPerk($"{id}{level}", "Quick Learner",
@@ -715,9 +720,9 @@ namespace TheIdleScrolls_Core.Resources
                                 [Tags.Damage],
                                 []),
                 ("AXE", 25) => PerkFactory.MakeStaticPerk($"{id}{level}", "Furious Swings",
-                                $"Gain {0.2:0.#} extra attacks per second with {id.Localize()}s",
+                                $"Gain {0.1:0.#} extra attacks per second with {id.Localize()}s",
                                 ModifierType.AddFlat,
-                                0.2,
+                                0.1,
                                 [Tags.AttackSpeed, Abilities.Axe],
                                 []),
                 ("BLN", 25) => new($"{id}{level}", "Stunning Blow",
@@ -825,7 +830,7 @@ namespace TheIdleScrolls_Core.Resources
                                 })
                 { MaxLevel = 3 },
                 ("SBL", 75) => new($"{id}{level}", "Critical Strikes",
-                                $"Deal {1.5:0.#%} increased damage with {id.Localize()}s once every {5}/{4}/{3} attacks",
+                                $"Deal {1.0:0.#%}/{1.5:0.#%}/{2.0:0.#%} increased damage with {id.Localize()}s once every {5}/{4}/{3} attacks",
                                 [UpdateTrigger.AttackPerformed, UpdateTrigger.BattleStarted],
                                 (l, e, w, c) =>
                                 {
@@ -833,7 +838,7 @@ namespace TheIdleScrolls_Core.Resources
                                     bool bonus = (attacks % (6 - l)) == (5 - l);
                                     return [ new($"{id}{level}",
                                              ModifierType.Increase,
-                                             bonus ? 1.5 : 0.0,
+                                             bonus ? 0.5 * (l + 1) : 0.0,
                                             [ Tags.Damage, Abilities.ShortBlade ],
                                             [])
                                     ];
@@ -966,14 +971,14 @@ namespace TheIdleScrolls_Core.Resources
                     MaxLevel = 5
                 },
                 (Abilities.DualWield, 75) => new($"{id}{level}", "Assassin",
-                                    $"Gain {0.1} base damage per level of the {Properties.LocalizedStrings.ABL_DUALWIELD} ability",
+                                    $"Gain {DualWieldKeystone} base damage per level of the {Properties.LocalizedStrings.ABL_DUALWIELD} ability",
                                     [UpdateTrigger.AbilityIncreased],
                                     (_, e, w, c) =>
                                     {
                                         int lvl = e.GetComponent<AbilitiesComponent>()?.GetAbility(id)?.Level ?? 0;
                                         return
                                         [
-                                            new($"{id}{level}_dmg", ModifierType.AddBase, 0.1 * lvl,
+                                            new($"{id}{level}_dmg", ModifierType.AddBase, DualWieldKeystone * lvl,
                                                 [ Tags.Damage ],
                                                 []
                                             )
@@ -998,7 +1003,7 @@ namespace TheIdleScrolls_Core.Resources
                     MaxLevel = 5
                 },
                 (Abilities.Shielded, 75) => new($"{id}{level}", "Juggernaut",
-                                    $"Gain {0.001:0.###%} increased damage per {1000} points of armor rating per level of " +
+                                    $"Gain {ShieldedKeystone:0.###%} increased damage per {1000} points of armor rating per level of " +
                                     $"the {Properties.LocalizedStrings.ABL_SHIELDED} ability",
                                     [UpdateTrigger.AbilityIncreased, UpdateTrigger.EquipmentChanged,
                                         UpdateTrigger.BattleStarted, UpdateTrigger.AttackPerformed],
@@ -1008,7 +1013,7 @@ namespace TheIdleScrolls_Core.Resources
                                         int lvl = e.GetComponent<AbilitiesComponent>()?.GetAbility(id)?.Level ?? 0;
                                         return
                                         [
-                                            new($"{id}{level}_dmg", ModifierType.Increase, 0.001 * (lvl * armor / 1000.0),
+                                            new($"{id}{level}_dmg", ModifierType.Increase, ShieldedKeystone * (lvl * armor / 1000.0),
                                                 [ Tags.Damage ],
                                                 []
                                             )
@@ -1044,7 +1049,7 @@ namespace TheIdleScrolls_Core.Resources
                                     })
                 { MaxLevel = 5 },
                 (Abilities.SingleHanded, 75) => new($"{id}{level}", "Duelist",
-                                    $"Gain {0.02:0.#%} increased damage per level of the " +
+                                    $"Gain {SingleHandedKeystone:0.#%} increased damage per level of the " +
                                         $"{Properties.LocalizedStrings.ABL_SINGLEHANDED} ability while evading",
                                     [UpdateTrigger.AbilityIncreased],
                                     (_, e, w, c) =>
@@ -1052,7 +1057,7 @@ namespace TheIdleScrolls_Core.Resources
                                         int lvl = e.GetComponent<AbilitiesComponent>()?.GetAbility(id)?.Level ?? 0;
                                         return
                                         [
-                                            new($"{id}{level}_dmg", ModifierType.Increase, 0.02 * lvl,
+                                            new($"{id}{level}_dmg", ModifierType.Increase, SingleHandedKeystone * lvl,
                                                 [Tags.Damage],
                                                 [Tags.Evading]
                                             )
@@ -1077,7 +1082,7 @@ namespace TheIdleScrolls_Core.Resources
                     MaxLevel = 5
                 },
                 (Abilities.TwoHanded, 75) => new($"{id}{level}", "Executioner",
-                                    $"Gain {0.01:0.#%} increased damage per second of attack time per level of " +
+                                    $"Gain {TwoHandedKeystone:0.#%} increased damage per second of attack time per level of " +
                                     $"{Properties.LocalizedStrings.ABL_TWOHANDED} ability",
                                     [UpdateTrigger.AbilityIncreased, UpdateTrigger.EquipmentChanged,
                                         UpdateTrigger.BattleStarted, UpdateTrigger.AttackPerformed],
@@ -1087,7 +1092,7 @@ namespace TheIdleScrolls_Core.Resources
                                         int lvl = e.GetComponent<AbilitiesComponent>()?.GetAbility(id)?.Level ?? 0;
                                         return
                                         [
-                                            new($"{id}{level}_dmg", ModifierType.Increase, cooldown * lvl / 100,
+                                            new($"{id}{level}_dmg", ModifierType.Increase, TwoHandedKeystone * cooldown * lvl,
                                                 [ Tags.Damage ],
                                                 []
                                             )
@@ -1134,10 +1139,10 @@ namespace TheIdleScrolls_Core.Resources
                                         int lvlTH = abilitiesComp?.GetAbility(Abilities.TwoHanded)?.Level ?? 0;
                                         return
                                         [
-                                            new($"{id}{level}_DW", ModifierType.AddBase, 0.05 * lvlDW, [Tags.Damage], []),
-                                            new($"{id}{level}_Sh", ModifierType.Increase, 0.001 * (lvlSh * armor / 2000.0), [Tags.Damage], []),
-                                            new($"{id}{level}_Si", ModifierType.Increase, 0.01 * lvlSi, [Tags.Damage], [Tags.Evading]),
-                                            new($"{id}{level}_TH", ModifierType.Increase, cooldown * lvlTH / 200.0, [Tags.Damage], [])
+                                            new($"{id}{level}_DW", ModifierType.AddBase, DualWieldKeystone / 2 * lvlDW, [Tags.Damage], []),
+                                            new($"{id}{level}_Sh", ModifierType.Increase, ShieldedKeystone / 2 * (lvlSh * armor / 1000.0), [Tags.Damage], []),
+                                            new($"{id}{level}_Si", ModifierType.Increase, SingleHandedKeystone / 2 * lvlSi, [Tags.Damage], [Tags.Evading]),
+                                            new($"{id}{level}_TH", ModifierType.Increase, TwoHandedKeystone / 2 * cooldown * lvlTH, [Tags.Damage], [])
                                         ];
                                     }),
                 _ => null

--- a/TheIdleScrolls_Core/Resources/AchievementList.cs
+++ b/TheIdleScrolls_Core/Resources/AchievementList.cs
@@ -275,7 +275,7 @@ namespace TheIdleScrolls_Core.Resources
                 Conditions.MobsDefeatedConditionallyCondition(Tags.DualWield, mobsForAdvStyles))
             {
                 Reward = new PerkReward(new("Adv" + Abilities.DualWield, "Weapon Block", 
-                    $"Gain {3}/{6}/{10} global base evasion rating per level of the Two Weapons ability", 
+                    $"While using two weapons, gain {3}/{6}/{10} global base evasion rating per level of the Two Weapons ability", 
                     [UpdateTrigger.AbilityIncreased], 
                     (l, e, w, c) => {
                         int level = e.GetComponent<AbilitiesComponent>()?

--- a/TheIdleScrolls_Core/Resources/AchievementList.cs
+++ b/TheIdleScrolls_Core/Resources/AchievementList.cs
@@ -964,8 +964,8 @@ namespace TheIdleScrolls_Core.Resources
                                     [],
                                     (l, e, w, c) =>
                                     [
-                                        new($"{id}{level}_as", ModifierType.More, Math.Pow(1.09, l) - 1.0, [ Tags.AttackSpeed ], []),
-                                        new($"{id}{level}_def", ModifierType.More, Math.Pow(0.95, l) - 1.0, [ Tags.Defense ], [])
+                                        new($"{id}{level}_as", ModifierType.More, Math.Pow(Stats.TradeoffPerkBonus, l) - 1.0, [ Tags.AttackSpeed ], []),
+                                        new($"{id}{level}_def", ModifierType.More, Math.Pow(Stats.TradeoffPerkMalus, l) - 1.0, [ Tags.Defense ], [])
                                     ])
                 {
                     MaxLevel = 5
@@ -996,8 +996,8 @@ namespace TheIdleScrolls_Core.Resources
                                     [],
                                     (l, e, w, c) =>
                                     [
-                                        new($"{id}{level}_def", ModifierType.More, Math.Pow(1.09, l) - 1.0, [ Tags.Defense ], []),
-                                        new($"{id}{level}_dmg", ModifierType.More, Math.Pow(0.95, l) - 1.0, [ Tags.Damage ], [])
+                                        new($"{id}{level}_def", ModifierType.More, Math.Pow(Stats.TradeoffPerkBonus, l) - 1.0, [ Tags.Defense ], []),
+                                        new($"{id}{level}_dmg", ModifierType.More, Math.Pow(Stats.TradeoffPerkMalus, l) - 1.0, [ Tags.Damage ], [])
                                     ])
                 {
                     MaxLevel = 5
@@ -1075,8 +1075,8 @@ namespace TheIdleScrolls_Core.Resources
                                     [],
                                     (l, e, w, c) =>
                                     [
-                                        new($"{id}{level}_dmg", ModifierType.More, Math.Pow(1.09, l) - 1.0, [ Tags.Damage ], []),
-                                        new($"{id}{level}_as", ModifierType.More, Math.Pow(0.95, l) - 1.0, [ Tags.AttackSpeed ], [])
+                                        new($"{id}{level}_dmg", ModifierType.More, Math.Pow(Stats.TradeoffPerkBonus, l) - 1.0, [ Tags.Damage ], []),
+                                        new($"{id}{level}_as", ModifierType.More, Math.Pow(Stats.TradeoffPerkMalus, l) - 1.0, [ Tags.AttackSpeed ], [])
                                     ])
                 {
                     MaxLevel = 5

--- a/TheIdleScrolls_Core/Resources/AchievementList.cs
+++ b/TheIdleScrolls_Core/Resources/AchievementList.cs
@@ -291,7 +291,7 @@ namespace TheIdleScrolls_Core.Resources
             });
 
             // Fighting style level achievements
-            achievements.Add(new(Abilities.DualWield + "25", "Ambidextrous",
+            achievements.Add(new(Abilities.DualWield + "25", "Dual Weapon Apprentice",
                 $"Reach ability level {25} for the {AbilityList.GetAbility(Abilities.DualWield)!.Name} style",
                 Conditions.AchievementUnlockedCondition(Abilities.DualWield),
                 Conditions.HasLevelledAllAbilitiesCondition([Abilities.DualWield], 25))
@@ -953,12 +953,12 @@ namespace TheIdleScrolls_Core.Resources
                                     Stats.SavantXpMultiplier,
                                     [Tags.AbilityXpGain, id],
                                     [], true),
-                (Abilities.DualWield, 25) => PerkFactory.MakeStaticPerk($"{id}{level}", $"Ambidextrous",
-                                    $"{Stats.DualWieldAttackSpeedMulti:0.#%} more attack speed while dual wielding",
-                                    ModifierType.More,
-                                    Stats.DualWieldAttackSpeedMulti,
-                                    [Tags.AttackSpeed],
-                                    [Tags.DualWield]),
+                (Abilities.DualWield, 25) => PerkFactory.MakeStaticMultiModPerk($"{id}{level}", $"Versatile",
+                                    $"Gain {0.05:0.#%} more damage, attack speed and defense while using two weapons",
+                                    Enumerable.Repeat(ModifierType.More, 3).ToList(),
+                                    Enumerable.Repeat(0.05, 3).ToList(),
+                                    [[Tags.Damage], [Tags.AttackSpeed], [Tags.Defense]],
+                                    Enumerable.Repeat<IEnumerable<string>>([Tags.DualWield], 3).ToList()),
                 (Abilities.DualWield, 50) => new($"{id}{level}", "Reckless Assault",
                                     $"Sacrifice some defense to gain an exponentially increasing multiplier to attack speed",
                                     [],

--- a/TheIdleScrolls_Core/Systems/EquipmentManagementSystem.cs
+++ b/TheIdleScrolls_Core/Systems/EquipmentManagementSystem.cs
@@ -46,8 +46,7 @@ namespace TheIdleScrolls_Core.Systems
                 Entity item = coordinator.GetEntity(move.ItemId) ?? throw new Exception($"No item with id {move.ItemId}");
                 if (move.Equip)
                 {
-                    bool inInventory = inventoryComp.GetItems().Contains(item);
-                    if (inInventory)
+                    if (inventoryComp.GetItems().Contains(item))
                     {
                         var equippableComp = item.GetComponent<EquippableComponent>();
                         if (equippableComp == null)
@@ -144,6 +143,14 @@ namespace TheIdleScrolls_Core.Systems
         private static Entity? FindBlockingItem(EquipmentComponent equipment, List<EquipmentSlot> slots, bool takeSlotsBackwards)
         {
             List<Entity> items = equipment.GetItems();
+
+            // Manual handling of edge case: this can happen when trying to equip a shield while 
+            // the main hand is free and the off hand is occupied by another shield
+            if (slots.Count == 0)
+            {
+                return items.FirstOrDefault(e => e.IsShield());
+            }
+
             if (takeSlotsBackwards) // Shields go in the last slot first
                 items.Reverse();
             foreach (var item in items)

--- a/TheIdleScrolls_Core/Systems/PerksSystem.cs
+++ b/TheIdleScrolls_Core/Systems/PerksSystem.cs
@@ -153,6 +153,12 @@ namespace TheIdleScrolls_Core.Systems
 
         static void AddBasicPerks(PerksComponent perksComponent)
         {
+            // Inherent bonus for dual wielding
+            perksComponent.AddPerk(PerkFactory.MakeStaticPerk("Ambidextrous", "Ambidextrous", "", 
+                ModifierType.More, 
+                Stats.DualWieldAttackSpeedMulti,
+                [Tags.AttackSpeed], [Tags.DualWield], true), 0);
+
             // Create perk that bundles the bonuses to ability experience gains
             perksComponent.AddPerk(new("NaturalAffinities", "Natural Affinity",
                 "Gain increased experience with for your abilities",

--- a/TheIdleScrolls_Core/Systems/StatUpdateSystem.cs
+++ b/TheIdleScrolls_Core/Systems/StatUpdateSystem.cs
@@ -63,6 +63,13 @@ namespace TheIdleScrolls_Core.Systems
                     encumbrance += item.GetComponent<EquippableComponent>()?.Encumbrance ?? 0.0;
                     var localTags = item.GetTags();
 
+                    // Add situational local tags 
+                    var slots = item.GetRequiredSlots();
+                    if (slots.Count == 1 && slots[0] == EquipmentSlot.Hand)
+                    {
+                        localTags.Add((item.IsShield() || weaponCount > 0) ? Tags.OffHand : Tags.MainHand);
+                    }
+
                     if (itemComp != null && weaponComp != null)
                     {
                         double localDmg = weaponComp.Damage;

--- a/TheIdleScrolls_Core/Systems/StatUpdateSystem.cs
+++ b/TheIdleScrolls_Core/Systems/StatUpdateSystem.cs
@@ -86,6 +86,7 @@ namespace TheIdleScrolls_Core.Systems
 
                         combinedDmg += localDmg;
                         combinedCD += localCD;
+                        //Console.WriteLine($"{item.GetName()}({weaponCount}): Dmg: {localDmg} -> {combinedDmg}; CD: {localCD} -> {combinedCD}");
                     }
 
                     if (itemComp != null && armorComp != null)

--- a/TheIdleScrolls_Web/Components/AchievementDisplay.razor
+++ b/TheIdleScrolls_Web/Components/AchievementDisplay.razor
@@ -5,18 +5,28 @@
 
 @inject CoreWrapperModel CoreWrapper
 
-<div class="ach-container">
+@if (SelectedAchievement != null)
+{
+    <div class="achievement @(GetAchievementClasses(SelectedAchievement))">
+        <div class="ach-title">@SelectedAchievement.Title</div>
+        <div class="ach-description">@SelectedAchievement.Description</div>
+        @if (SelectedAchievement.Reward != string.Empty)
+        {
+            <div class="ach-reward">➤ Reward: @SelectedAchievement.Reward</div>
+        }
+    </div>
+}
 
+<div class="ach-container">
+    
     <div class="ach-list">
         @foreach (var achievement in Achievements.Where(IsVisible))
         {
-            <div class="achievement @(GetAchievementClasses(achievement))">
+            <div class="achievement-mini @(GetAchievementClasses(achievement))"
+                @onmouseenter="(() => SelectedAchievement = achievement)"
+                @onmouseleave="(() => SelectedAchievement = null)"
+            >
                 <div class="ach-title">@achievement.Title</div>
-                <div class="ach-description">@achievement.Description</div>
-                @if (achievement.Reward != string.Empty)
-                {
-                    <div class="ach-reward">➤ Reward: @achievement.Reward</div>
-                }
             </div>
         }
     </div>
@@ -44,6 +54,7 @@
         display: flex;
         flex-direction: column;
         overflow-y: auto;
+        position: relative;
     }
 
     .ach-header {
@@ -58,13 +69,15 @@
     }
 
     .ach-list {
-        display: flex;
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
         flex-direction: column;
         flex: 1;
         max-height: 100%;
         overflow-y: auto;
         margin: 0;
         padding: 5px;
+        gap: 0.5rem;
     }
 
     .ach-new-indicator {
@@ -80,11 +93,30 @@
         text-align: center;
     }
 
-    .achievement {
-        margin: 5px;
+    .achievement-mini {
         padding: 5px;
-        /* width: 70%; */
         border: 1px solid var(--frame-color);
+        align-items: center;
+        position: relative;
+        box-sizing: border-box;
+    }
+
+    .achievement-mini:hover {
+        border-width: 2px;
+        margin: -1px;
+    }
+
+    .achievement {
+        padding: 0.5rem;
+        width: 50%;
+        min-height: 8rem;
+        border: 3px solid var(--frame-color);
+
+        position: absolute;
+        z-index: 3;
+        left: 50%;
+        bottom: 100%;
+        transform: translate(-50%, -0.5rem);
     }
 
     .ach-earned {
@@ -134,6 +166,8 @@
     List<string> SeenEarnedAchievements {get; set;} = new List<string>();
     int NewAchievements => AchievementsEarned - SeenEarnedAchievements.Count;
 
+    AchievementRepresentation? SelectedAchievement { get; set; } = null;
+
     bool IsVisible(AchievementRepresentation achievement)
     {
         return !HideEarned || !SeenEarnedAchievements.Contains(achievement.Title);
@@ -166,7 +200,7 @@
 
     private string GetAchievementClasses(AchievementRepresentation achievement)
     {
-        string classes = "achievement ";
+        string classes = "";
         classes += achievement.Earned ? "ach-earned" : "ach-unearned";
 
         if (achievement.Earned && !SeenEarnedAchievements.Contains(achievement.Title))

--- a/TheIdleScrolls_Web/Components/AchievementDisplay.razor
+++ b/TheIdleScrolls_Web/Components/AchievementDisplay.razor
@@ -8,7 +8,7 @@
 <div class="ach-container">
 
     <div class="ach-list">
-        @foreach (var achievement in Achievements.Where(a => !HideEarned || !a.Earned))
+        @foreach (var achievement in Achievements.Where(IsVisible))
         {
             <div class="achievement @(GetAchievementClasses(achievement))">
                 <div class="ach-title">@achievement.Title</div>
@@ -24,7 +24,7 @@
     <div class="ach-header">
         <p style="margin-bottom: 0">Completed: @AchievementsEarned / @TotalAchievements</p>
         <div>
-            <label>Hide completed</label>
+            <label>Hide previously completed</label>
             <input type="checkbox" checked="@HideEarned" @onclick="(() => HideEarned = !HideEarned)" />
         </div>
     </div>
@@ -60,7 +60,7 @@
     .ach-list {
         display: flex;
         flex-direction: column;
-        flex: 1 1 auto;
+        flex: 1;
         max-height: 100%;
         overflow-y: auto;
         margin: 0;
@@ -133,6 +133,11 @@
 
     List<string> SeenEarnedAchievements {get; set;} = new List<string>();
     int NewAchievements => AchievementsEarned - SeenEarnedAchievements.Count;
+
+    bool IsVisible(AchievementRepresentation achievement)
+    {
+        return !HideEarned || !SeenEarnedAchievements.Contains(achievement.Title);
+    }
 
     AchievementsChangedHandler AchChangedHandler => (List<AchievementRepresentation> achievements, int count) =>
     {

--- a/TheIdleScrolls_Web/Components/Changelog.razor
+++ b/TheIdleScrolls_Web/Components/Changelog.razor
@@ -5,7 +5,7 @@
 
 <h3>Recent Changes</h3>
 
-<div style="max-width: 1000px" markdown="1">
+<div class="version-block">
     <h4>@GameVersion.GetVersionString(0, 8, 2)</h4>
     
     <h5>Bug Fixes</h5>
@@ -58,11 +58,10 @@
         <li>Replaced reductions to <em>Crafting Cost</em> with increases to <em>Crafting cost efficiency</em>. Cost is divided 
             by cost efficiency, so an increase of 100% halves crafting cost.</li>
     </ul>
-
 </div>
 
 
-<div style="max-width: 1000px">
+<div class="version-block">
     <h4>@GameVersion.GetVersionString(0, 8, 1)</h4>
         
     <h5>Bugfixes</h5>
@@ -145,6 +144,14 @@
     </ul>
 </div>
 
+<style>
+    div.version-block {
+        max-width: 1000px;
+        padding-bottom: 1rem;
+        border-bottom: double 3px slategray;
+        margin-bottom: 2rem;
+    }
+</style>
 
 @code {
     

--- a/TheIdleScrolls_Web/Components/Changelog.razor
+++ b/TheIdleScrolls_Web/Components/Changelog.razor
@@ -5,39 +5,62 @@
 
 <h3>Recent Changes</h3>
 
-<div style="max-width: 1000px">
+<div style="max-width: 1000px" markdown="1">
     <h4>@GameVersion.GetVersionString(0, 8, 2)</h4>
-
-    <h5>Bugfixes</h5>
+    
+    <h5>Bug Fixes</h5>
     <ul>
+        <li>Refining of training items is no longer instantaneous</li>
+        <li>Replacing a worn shield with another shield was not possible while the character&#39;s main hand was empty</li>
     </ul>
 
     <h5>Balancing</h5>
-    
-    <h6>General</h6>
     <ul>
+        <li><strong>Ambidextrous</strong> is now permanent and grants 10% more attack speed (down from 20%)</li>
+        <li><strong>Assassin</strong>: Gain 0.2 base Damage per level of Two Weapons (up from 0.1)</li>
+        <li><strong>Basic Damage</strong>: Gain 12% increased damage per point invested (up from 10%)</li>
+        <li><strong>Basic Time Limit</strong>: Gain 12% increased time limit per point invested (up from 5%)</li>
+        <li><strong>Critical Strikes</strong>: Gain 100%/150%/200% damage instead of 150% at all levels</li>
+        <li><strong>Furious Swings</strong>: Gain 0.1 extra attacks per second (down from 0.2)</li>
+        <li><strong>Methodical</strong>, <strong>Precise Attacks</strong>, <strong>Reckless Assault</strong> now gain a 5% 
+            multiplier to one stat at the cost of 3% of another (down from 9% and 5% respectively)</li>
     </ul>
 
-    <h6>Perks</h6>
+    <h5>Achievements</h5>
     <ul>
+        <li>Added four new achievements that are unlocked by defeating 1000 enemies using one of the four fighting styles</li>
+        <li><strong>Patrician</strong> now requires gathering a total of 250000 coins (down from 500000)</li>
     </ul>
 
-    <h5>Quality of Life Improvements</h5>
+    <h5>Perks</h5>
     <ul>
-    </ul>
-
-    <h5>New Achievements</h5>
-    <ul>
-    </ul>
-
-    <h5>New Perks</h5>
-    <ul>
+        <li>
+            <strong>Versatile</strong>: 5% more damage, attack speed and defense while using two weapons
+            <ul>
+                <li>Replaces Ambidextrous as reward the <strong>Dual Weapon Apprentice</strong> achievement</li>
+            </ul>
+        </li>
+        <li><strong>Distance Control</strong>: Gain 30/60/100% of your two-handed weapon&#39;s damage as global base armor</li>
+        <li><strong>Seize the Moment</strong>: While fighting single-handedly, gain 7/15/25% increased attack speed while evading</li>
+        <li><strong>Shield Bash</strong>: Every third attack, gain 4/7/10 base damage + 1/2/4 per level of quality on your shield</li>
+        <li><strong>Weapon Block</strong>: While using two weapons, gain 3/6/10 global base evasion rating per level of the Two Weapons ability</li>
     </ul>
 
     <h5>Miscellaneous</h5>
     <ul>
+        <li>Stats of a selected item are now compared to those of the item(s) currently equipped in its required slot(s).</li>
+        <li>Frame time is now capped at 200ms to prevent issues caused by the browser throttling the game&#39;s tab.</li>
+        <li>Achievement list is now more compact</li>
+        <li>An info message is now shown upon earning a title</li>
+        <li>Info messages can now be hidden by clicking on them</li>
+        <li>Names of crafted items are no longer displayed in italic font</li>
+        <li>The <em>Hide completed</em> checkbox on the Achievements page no longer hides newly earned achievements</li>
+        <li>Replaced reductions to <em>Crafting Cost</em> with increases to <em>Crafting cost efficiency</em>. Cost is divided 
+            by cost efficiency, so an increase of 100% halves crafting cost.</li>
     </ul>
+
 </div>
+
 
 <div style="max-width: 1000px">
     <h4>@GameVersion.GetVersionString(0, 8, 1)</h4>
@@ -54,12 +77,12 @@
     </ul>
     <h6>Perks</h6>
     <ul>
-        <li><b>Elegant Parry</b> now gives 40% of your light shields base armor as evasion (up from 30%)</li>
-        <li><b>Quick Slash</b> now deals 100% more damage on top the 100% more attack speed. A truly masterful stroke!</li>
-        <li><b>Sneak Attack</b> now deals 100% more damage for every 25 levels of the Short Blade ability (up to 800% at level 200)</li>
-        <li><b>Stunning Blow</b> now adds +1 global base armor per level of the Blunt Weapon ability</li>
-        <li><b>Elusive</b> and <b>Ethereal Form</b> now scale with the level of the Unarmored ability instead of the character level</li>
-        <li><b>Iron Fists</b> and <b>Force of Spirit</b> now scale with the level of the Unarmed ability instead of the character level</li>
+        <li><strong>Elegant Parry</strong> now gives 40% of your light shields base armor as evasion (up from 30%)</li>
+        <li><strong>Quick Slash</strong> now deals 100% more damage on top the 100% more attack speed. A truly masterful stroke!</li>
+        <li><strong>Sneak Attack</strong> now deals 100% more damage for every 25 levels of the Short Blade ability (up to 800% at level 200)</li>
+        <li><strong>Stunning Blow</strong> now adds +1 global base armor per level of the Blunt Weapon ability</li>
+        <li><strong>Elusive</strong> and <strong>Ethereal Form</strong> now scale with the level of the Unarmored ability instead of the character level</li>
+        <li><strong>Iron Fists</strong> and <strong>Force of Spirit</strong> now scale with the level of the Unarmed ability instead of the character level</li>
     </ul>
 
     <h5>Rebalanced Crafting</h5>
@@ -96,16 +119,16 @@
 
     <h5>New Achievements</h5>
     <ul>
-        <li><b>Void Conqueror:</b> Complete an endgame dungeon</li>
-        <li><b>Void Emperor:</b> Complete an endgame dungeon at area level 200</li>
-        <li><b>Exalted Conqueror:</b> Complete the three endgame dungeons without losing a single fight</li>
-        <li><b>Exalted Emperor:</b> Complete the three endgame dungeons at area level 200 without losing a single fight</li>
-        <li><b>Happy Pride:</b> Wear items with six different quality levels above 0 at the same time</li>
+        <li><strong>Void Conqueror:</strong> Complete an endgame dungeon</li>
+        <li><strong>Void Emperor:</strong> Complete an endgame dungeon at area level 200</li>
+        <li><strong>Exalted Conqueror:</strong> Complete the three endgame dungeons without losing a single fight</li>
+        <li><strong>Exalted Emperor:</strong> Complete the three endgame dungeons at area level 200 without losing a single fight</li>
+        <li><strong>Happy Pride:</strong> Wear items with six different quality levels above 0 at the same time</li>
     </ul>
 
     <h5>New Perks</h5>
     <ul>
-        <li><b>Well Dressed:</b> 0.5% increased damage and defenses for each level of quality on your gear</li>
+        <li><strong>Well Dressed:</strong> 0.5% increased damage and defenses for each level of quality on your gear</li>
     </ul>
 
     <h5>Miscellaneous</h5>

--- a/TheIdleScrolls_Web/Components/Changelog.razor
+++ b/TheIdleScrolls_Web/Components/Changelog.razor
@@ -6,6 +6,40 @@
 <h3>Recent Changes</h3>
 
 <div style="max-width: 1000px">
+    <h4>@GameVersion.GetVersionString(0, 8, 2)</h4>
+
+    <h5>Bugfixes</h5>
+    <ul>
+    </ul>
+
+    <h5>Balancing</h5>
+    
+    <h6>General</h6>
+    <ul>
+    </ul>
+
+    <h6>Perks</h6>
+    <ul>
+    </ul>
+
+    <h5>Quality of Life Improvements</h5>
+    <ul>
+    </ul>
+
+    <h5>New Achievements</h5>
+    <ul>
+    </ul>
+
+    <h5>New Perks</h5>
+    <ul>
+    </ul>
+
+    <h5>Miscellaneous</h5>
+    <ul>
+    </ul>
+</div>
+
+<div style="max-width: 1000px">
     <h4>@GameVersion.GetVersionString(0, 8, 1)</h4>
         
     <h5>Bugfixes</h5>

--- a/TheIdleScrolls_Web/Components/ExpiringMessagesDisplay.razor
+++ b/TheIdleScrolls_Web/Components/ExpiringMessagesDisplay.razor
@@ -5,17 +5,17 @@
 
 @inject CoreWrapperModel CoreWrapper
 
-<div id="timedMessageArea">
+<div class="timedMessageArea">
 	@foreach (var message in CoreWrapper.ExpiringMessages.Where(m => !m.Expired))
 	{
-		<div class="timed-message">
+		<div class="timed-message" @onclick=@(() => message.SetExpired())>
 			@message.Message
 		</div>
 	}
 </div>
 
 <style>
-	#timedMessageArea {
+	.timedMessageArea {
 		position: absolute;
 		right: 0;
 		top: 0;
@@ -33,6 +33,7 @@
 		width: 100%;
 		padding: 5px;
 		overflow-x: hidden;
+		cursor: pointer;
 	}
 </style>
 

--- a/TheIdleScrolls_Web/Components/HelpDisplay.razor
+++ b/TheIdleScrolls_Web/Components/HelpDisplay.razor
@@ -23,8 +23,8 @@
         </p>
 
         <h4>Weapons</h4>
-        <p>Weapons are occupy either one or both hand slots.</p> 
-        <p>You are allowed to wield two one-handed weapons at the same time. Your attack damage while dual wielding is the average of the
+        <p>Weapons occupy either one or both hand slots.</p> 
+        <p>You can also use two one-handed weapons at the same time. Your attack damage while dual wielding is the average of the
             weapons' damage values and you receive a multiplicative @($"{Stats.DualWieldAttackSpeedMulti:0.#%}") boost to your attack speed.
         </p>
     }

--- a/TheIdleScrolls_Web/Components/HighlightedItemDisplay.razor
+++ b/TheIdleScrolls_Web/Components/HighlightedItemDisplay.razor
@@ -1,5 +1,6 @@
 ﻿@using TheIdleScrolls_Core
 @using TheIdleScrolls_Core.Items
+@using TheIdleScrolls_Web.Components.Subcomponents
 @using TheIdleScrolls_Web.CoreWrapper
 
 @inject CoreWrapperModel CoreWrapper
@@ -12,9 +13,69 @@
             <span id="crafted-line">Crafted</span>
         }
         <div id="description-lines">
-            @foreach (string line in ItemDescriptionLines)
+            <span>@HighlightedItem?.Type</span>
+            <span>Level @HighlightedItem?.DropLevel</span>
+            <span>Ability: @HighlightedItem?.RelatedAbility</span>
+            @if (HighlightedItem?.WeaponAspect != null)
             {
-                <span>@line</span>
+                <span style="margin-top: 0.5rem">
+                    Damage: @HighlightedItem?.WeaponAspect?.BaseDamage
+                    @foreach (ComparisonResult comp in HighlightedItem?.CompareToEquipment(ItemComparator.CompareDamage) ?? [])
+                    {
+                        <ItemStatComparison ComparisonResult=@comp></ItemStatComparison>
+                    }
+                </span>
+                <span>
+                    Attack Time: @(HighlightedItem?.WeaponAspect?.BaseCooldown) s
+                    @foreach (ComparisonResult comp in HighlightedItem?.CompareToEquipment(ItemComparator.CompareCooldown) ?? [])
+                    {
+                        <ItemStatComparison ComparisonResult=@comp Suffix=" s"></ItemStatComparison>
+                    }
+                </span>
+                <span>
+                    DPS: @($"{HighlightedItem?.WeaponAspect?.Dps ?? 0.0:0.##}")
+                    @foreach (ComparisonResult comp in HighlightedItem?.CompareToEquipment(ItemComparator.CompareDps) ?? [])
+                    {
+                        <ItemStatComparison ComparisonResult=@comp></ItemStatComparison>
+                    }
+                </span>
+            }
+            @if (HighlightedItem?.ArmorAspect != null)
+            {
+                if ((HighlightedItem?.ArmorAspect?.BaseArmor ?? 0.0) != 0.0)
+                {
+                    <span style="margin-top: 0.5rem">
+                        Armor: @HighlightedItem?.ArmorAspect?.BaseArmor
+                        @foreach (ComparisonResult comp in HighlightedItem?.CompareToEquipment(ItemComparator.CompareArmor) ?? [])
+                        {
+                            <ItemStatComparison ComparisonResult=@comp></ItemStatComparison>
+                        }
+                    </span>
+                }
+                if ((HighlightedItem?.ArmorAspect?.BaseEvasion ?? 0.0) != 0.0)
+                {
+                    <span>
+                        Evasion: @HighlightedItem?.ArmorAspect?.BaseEvasion
+                        @foreach (ComparisonResult comp in HighlightedItem?.CompareToEquipment(ItemComparator.CompareEvasion) ?? [])
+                        {
+                            <ItemStatComparison ComparisonResult=@comp></ItemStatComparison>
+                        }
+                    </span>
+                }
+            }
+            @if (HighlightedItem?.Encumbrance != null && HighlightedItem?.Encumbrance > 0)
+            {
+                <span>
+                    Encumbrance: @(HighlightedItem?.Encumbrance)%
+                    @foreach (ComparisonResult comp in HighlightedItem?.CompareToEquipment(ItemComparator.CompareEncumbrance) ?? [])
+                    {
+                        <ItemStatComparison ComparisonResult=@comp Suffix="%"></ItemStatComparison>
+                    }
+                </span>
+            }
+            @if (HighlightedItem?.Value > 0)
+            {
+                <span style="margin-top: 0.5rem">Value: @HighlightedItem?.Value c</span>
             }
         </div>
     </div>
@@ -106,6 +167,10 @@
         margin-top: 5px;
         display: inherit;
         flex-direction: inherit;
+    }
+
+    span.important {
+        font-weight: bold;
     }
 
     #coins {
@@ -212,7 +277,7 @@
         }
     }
 
-void CraftItem()
+    void CraftItem()
     {
         if (HighlightedItem != null)
         {

--- a/TheIdleScrolls_Web/Components/PerkTile.razor
+++ b/TheIdleScrolls_Web/Components/PerkTile.razor
@@ -117,8 +117,16 @@
         background-color: greenyellow;
     }
 
+    button.perk-button-activate:hover {
+        background-color: lawngreen;
+    }
+
     button.perk-button-deactivate {
         background-color: coral;
+    }
+
+    button.perk-button-deactivate:hover {
+        background-color: lightcoral;
     }
 </style>
 

--- a/TheIdleScrolls_Web/Components/Subcomponents/ItemStatComparison.razor
+++ b/TheIdleScrolls_Web/Components/Subcomponents/ItemStatComparison.razor
@@ -1,0 +1,61 @@
+﻿@using TheIdleScrolls_Core.Items
+
+<span class="itemcomparison-container @GetQualityClass()">
+    <span class="itemcomparison-symbol">@GetSymbol()</span>
+    <span class="itemcomparison-value">@GetValueText()</span>
+</span>
+
+<style>
+    .itemcomparison-container {
+        margin-left: 1rem;
+    }
+
+    .itemcomparison-container.item-equal {
+        color: gray;
+    }
+
+    .itemcomparison-container.item-better {
+        color: green;
+        font-weight: bold;
+    }
+
+    .itemcomparison-container.item-worse {
+        color: red;
+        font-weight: bold;
+    }
+
+    .itemcomparison-symbol {
+        font-family: 'Arrows';
+    }
+
+</style>
+
+@code {
+    [Parameter]
+    public ComparisonResult ComparisonResult { get; set; } = new(RelativeQuality.Equal, 0.0);
+    [Parameter]
+    public string Suffix { get; set; } = "";
+
+    string GetSymbol()
+    {
+        return (ComparisonResult.Difference == 0.0)
+            ? "KL"
+            : (ComparisonResult.Difference > 0.0)
+                ? "C"
+                : "D";
+    }
+
+    string GetValueText()
+    {
+        return $"{Math.Abs(ComparisonResult.Difference):0.##}{Suffix}";
+    }
+
+    string GetQualityClass()
+    {
+        return (ComparisonResult.Quality == RelativeQuality.Equal)
+            ? "item-equal"
+            : (ComparisonResult.Quality == RelativeQuality.Better)
+                ? "item-better"
+                : "item-worse";
+    }
+}

--- a/TheIdleScrolls_Web/CoreWrapper/CoreWrapperModel.cs
+++ b/TheIdleScrolls_Web/CoreWrapper/CoreWrapperModel.cs
@@ -121,8 +121,9 @@ namespace TheIdleScrolls_Web.CoreWrapper
                     sw.Start();
 
                     var delay = Task.Delay(frameTime);
+                    int actualFrameTime = Math.Min(4 * frameTime, frameTime + (int)owedTime);
 
-                    gameRunner.ExecuteTick((frameTime + owedTime) / 1000.0);
+                    gameRunner.ExecuteTick(actualFrameTime / 1000.0);
                     StateChanged?.Invoke();
 					owedTime = 0;
 					await delay;

--- a/TheIdleScrolls_Web/CoreWrapper/ExpiringMessage.cs
+++ b/TheIdleScrolls_Web/CoreWrapper/ExpiringMessage.cs
@@ -23,5 +23,10 @@
         {
             _expired = true;
         }
+
+        public void SetExpired()
+        {
+            _expired = true;
+        }
     }
 }

--- a/TheIdleScrolls_Web/Definitions/Version.cs
+++ b/TheIdleScrolls_Web/Definitions/Version.cs
@@ -4,7 +4,7 @@
     {
         const uint Major = 0;
         const uint Minor = 8;
-        const uint Patch = 1;
+        const uint Patch = 2;
 
         public static string GetCurrentVersionString()
         {

--- a/TheIdleScrolls_Web/wwwroot/css/app.css
+++ b/TheIdleScrolls_Web/wwwroot/css/app.css
@@ -186,7 +186,7 @@ div.progressFill {
     font-weight: bold;
 }
 .crafted-item {
-    font-style: italic;
+    
 }
 
 hr.thick {

--- a/TheIdleScrolls_Web/wwwroot/index.html
+++ b/TheIdleScrolls_Web/wwwroot/index.html
@@ -7,7 +7,7 @@
     <title>The Idle Scrolls</title>
     <base href="/" />
     <link href="css/bootstrap/bootstrap.min.css" rel="stylesheet" />
-    <link href="css/app.css" rel="stylesheet" />
+    <link href="css/app.css?version=0.8.2" rel="stylesheet" />
     <link href="TheIdleScrolls_Web.styles.css" rel="stylesheet" />
     <link href="css/custom_fonts.css" rel="stylesheet" />
 </head>


### PR DESCRIPTION

##### Bug Fixes
- Refining of training items is no longer instantaneous
- Replacing a worn shield with another shield was not possible while the character's main hand was empty

##### Balancing
- __Ambidextrous__ is now permanent and grants 10% more attack speed (down from 20%)
- __Assassin__: Gain 0.2 base Damage per level of Two Weapons (up from 0.1)
- __Basic Damage__: Gain 12% increased damage per point invested (up from 10%)
- __Basic Time Limit__: Gain 12% increased time limit per point invested (up from 5%)
- __Critical Strikes__: Gain 100%/150%/200% damage instead of 150% at all levels
- __Furious Swings__: Gain 0.1 extra attacks per second (down from 0.2)
- __Methodical__, __Precise Attacks__, __Reckless Assault__ now gain a 5% multiplier to one stat at the cost of 3% of another (down from 9% and 5% respectively)

##### Achievements
- Added four new achievements that are unlocked by defeating 1000 enemies using one of the four fighting styles
- __Patrician__ now requires gathering a total of 250000 coins (down from 500000)

##### Perks
- __Versatile__: 5% more damage, attack speed and defense while using two weapons
	- Replaces Ambidextrous as reward the Dual Weapon Apprentice achievement
- __Distance Control__: Gain 30/60/100% of your two-handed weapon's damage as global base armor
- __Seize the Moment__: While fighting single-handedly, gain 7/15/25% increased attack speed while evading
- __Shield Bash__: Every third attack, gain 4/7/10 base damage + 1/2/4 per level of quality on your shield
- __Weapon Block__: While using two weapons, gain 3/6/10 global base evasion rating per level of the Two Weapons ability

##### Miscellaneous
- Stats of a selected item are now compared to those of the item(s) currently equipped in its required slot(s).
- Frame time is now capped at 200 ms to prevent issues caused by the browser throttling the game's tab.
- Achievement list is now more compact
- An info message is now shown upon earning a title
- Info messages can now be hidden by clicking on them
- Names of crafted items are no longer displayed in italic font
- The _Hide completed_ checkbox on the Achievements page no longer hides newly earned achievements
- Replaced reductions to _Crafting Cost_ with increases to _Crafting cost efficiency_. Cost is divided by cost efficiency, so an increase of 100% halves crafting cost.